### PR TITLE
[Fix user reported bug][Enum support in DataClass]

### DIFF
--- a/lightrag/README.md
+++ b/lightrag/README.md
@@ -5,9 +5,9 @@
 <!-- [![GitHub star chart](https://img.shields.io/github/stars/SylphAI-Inc/LightRAG?style=flat-square)](https://star-history.com/#SylphAI-Inc/LightRAG) -->
 [![License](https://img.shields.io/github/license/SylphAI-Inc/LightRAG)](https://opensource.org/license/MIT)
 [![PyPI](https://img.shields.io/pypi/v/lightRAG?style=flat-square)](https://pypi.org/project/lightRAG/)
-[![PyPI - Downloads](https://img.shields.io/pypi/dm/lightRAG?style=flat-square)](https://pypistats.org/packages/lightRAG)
 [![Open Issues](https://img.shields.io/github/issues-raw/SylphAI-Inc/LightRAG?style=flat-square)](https://github.com/SylphAI-Inc/LightRAG/issues)
 [![](https://dcbadge.vercel.app/api/server/zt2mTPcu?compact=true&style=flat)](https://discord.gg/zt2mTPcu)
+<!-- [![PyPI - Downloads](https://img.shields.io/pypi/dm/lightRAG?style=flat-square)](https://pypistats.org/packages/lightRAG) -->
 
 
 ### ⚡ The Lightning Library for Large Language Model Applications ⚡

--- a/lightrag/lightrag/core/functional.py
+++ b/lightrag/lightrag/core/functional.py
@@ -19,6 +19,7 @@ from typing import (
 )
 import logging
 import numpy as np
+from enum import Enum
 import re
 import json
 import yaml
@@ -381,9 +382,23 @@ def get_type_schema(
         return "Tuple"
 
     elif is_dataclass(type_obj):
+        if issubclass(type_obj, Enum):
+            # Handle Enum dataclass types
+            enum_members = ", ".join([f"{e.name}={e.value}" for e in type_obj])
+            return f"Enum[{type_obj.__name__}({enum_members})]"
         # Recursively handle nested dataclasses
         output = str(get_dataclass_schema(type_obj, exclude, type_var_map))
         return output
+
+    elif isinstance(type_obj, type) and issubclass(type_obj, Enum):
+        # Handle Enum types
+        enum_members = ", ".join([f"{e.name}={e.value}" for e in type_obj])
+        return f"Enum[{type_obj.__name__}({enum_members})]"
+
+    # elif is_dataclass(type_obj):
+    #     # Recursively handle nested dataclasses
+    #     output = str(get_dataclass_schema(type_obj, exclude, type_var_map))
+    #     return output
     return type_obj.__name__ if hasattr(type_obj, "__name__") else str(type_obj)
 
 

--- a/lightrag/tests/test_base_data_class.py
+++ b/lightrag/tests/test_base_data_class.py
@@ -298,27 +298,52 @@ class TestGetTypeSchema(unittest.TestCase):
         print(f"instance: {instance}")
         self.assertEqual(restored_instance, instance)
 
-        from lightrag.core import Generator
-        from lightrag.components.model_client.openai_client import OpenAIClient
-        from lightrag.components.output_parsers import JsonOutputParser
-        from lightrag.utils import setup_env
+        # from lightrag.core import Generator
+        # from lightrag.components.model_client.openai_client import OpenAIClient
+        # from lightrag.components.output_parsers import JsonOutputParser
+        # from lightrag.utils import setup_env
 
-        setup_env()
-        parser = JsonOutputParser(
-            data_class=EnumListClassificationOutput, return_data_class=True
-        )
-        generator = Generator(
-            model_client=OpenAIClient(),
-            prompt_kwargs={
-                "task_desc_str": "Classify the following text as spam or not spam.",
-                "output_format_str": parser.format_instructions(),
+        # setup_env()
+        # parser = JsonOutputParser(
+        #     data_class=EnumListClassificationOutput, return_data_class=True
+        # )
+        # generator = Generator(
+        #     model_client=OpenAIClient(),
+        #     prompt_kwargs={
+        #         "task_desc_str": "Classify the following text as spam or not spam.",
+        #         "output_format_str": parser.format_instructions(),
+        #     },
+        #     model_kwargs={"model": "gpt-3.5-turbo"},
+        #     output_processors=parser,
+        # )
+        # prompt_kwargs = {"input_str": "This is a spam message."}
+        # result = generator(prompt_kwargs)
+        # print(f"result: {result}")
+
+    def test_enum_as_data_class(self):
+        @dataclass
+        class LabelDataClass(DataClass, str, enum.Enum):
+            """Enumeration for single-label text classification."""
+
+            SPAM = "spam"
+            NOT_SPAM = "not_spam"
+
+        schema = LabelDataClass.to_schema()
+        print(f"schema: {schema}")
+        type_schema = get_type_schema(LabelDataClass)
+        print(f"type_schema: {type_schema}")
+        self.assertEqual(
+            schema,
+            {
+                "type": "Enum[LabelDataClass(SPAM=spam, NOT_SPAM=not_spam)]",
+                "properties": {},
+                "required": [],
             },
-            model_kwargs={"model": "gpt-3.5-turbo"},
-            output_processors=parser,
         )
-        prompt_kwargs = {"input_str": "This is a spam message."}
-        result = generator(prompt_kwargs)
-        print(f"result: {result}")
+        self.assertEqual(
+            type_schema,
+            "Enum[LabelDataClass(SPAM=spam, NOT_SPAM=not_spam)]",
+        )
 
 
 if __name__ == "__main__":

--- a/lightrag/tests/test_base_data_class.py
+++ b/lightrag/tests/test_base_data_class.py
@@ -237,7 +237,7 @@ class TestBaseDataClass(unittest.TestCase):
         }
         output = Person.to_dict_class(exclude=exclude)
         print(f"output 1: {output}")
-        # self.assertEqual(output, expected_result)
+        self.assertEqual(output, expected_result)
 
     def test_error_non_dataclass(self):
         """Test error handling when to_dict is called on a non-dataclass."""
@@ -347,8 +347,5 @@ class TestGetTypeSchema(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    # class_format = ClassificationOutput.to_schema()
-    # class_instance = ClassificationOutput(label=Label.NOT_SPAM)
-    # print(class_format)
-    # print(class_instance.to_dict())
+
     unittest.main()


### PR DESCRIPTION
https://github.com/SylphAI-Inc/LightRAG/issues/134

After fix, we are able to get the right data for

```
class Label(str, enum.Enum):
    """Enumeration for single-label text classification."""

    SPAM = "spam"
    NOT_SPAM = "not_spam"


@dataclass
class ClassificationOutput(DataClass):
    """
    Class for a single class label prediction.
    """

    label: Label = field(metadata={"desc": "Label of the category."})
```

```
    @dataclass
            class EnumListClassificationOutput(DataClass):
                labels: List[Label] = field(
                    default_factory=list, metadata={"desc": "List of labels."}
                )

        from lightrag.core import Generator
        from lightrag.components.model_client.openai_client import OpenAIClient
        from lightrag.components.output_parsers import JsonOutputParser
        from lightrag.utils import setup_env

        setup_env()
        parser = JsonOutputParser(
            data_class=EnumListClassificationOutput, return_data_class=True
        )
        generator = Generator(
            model_client=OpenAIClient(),
            prompt_kwargs={
                "task_desc_str": "Classify the following text as spam or not spam.",
                "output_format_str": parser.format_instructions(),
            },
            model_kwargs={"model": "gpt-3.5-turbo"},
            output_processors=parser,
        )
        prompt_kwargs = {"input_str": "This is a spam message."}
        result = generator(prompt_kwargs)
        print(f"result: {result}")
```

Thegenerator output

```
result: GeneratorOutput(data=TestGetTypeSchema.test_enum_as_list_element.<locals>.EnumListClassificationOutput(labels=['SPAM']), error=None, usage=None, raw_response='```json\n{\n    "labels": ["SPAM"]\n}\n```', metadata=None)
```

After Fix

```
{'type': 'ClassificationOutput', 'properties': {'label': {'type': 'Enum[Label(SPAM=spam, NOT_SPAM=not_spam)]', 'desc': 'Label of the category.'}}, 'required': ['label']}
{'label': <Label.NOT_SPAM: 'not_spam'>}
```

Also support

```
@dataclass
        class LabelDataClass(DataClass, str, enum.Enum):
            """Enumeration for single-label text classification."""

            SPAM = "spam"
            NOT_SPAM = "not_spam"

schema = LabelDataClass.to_schema()
        print(f"schema: {schema}")
        type_schema = get_type_schema(LabelDataClass)
        print(f"type_schema: {type_schema}")
        self.assertEqual(
            schema,
            {
                "type": "Enum[LabelDataClass(SPAM=spam, NOT_SPAM=not_spam)]",
                "properties": {},
                "required": [],
            },
        )
        self.assertEqual(
            type_schema,
            "Enum[LabelDataClass(SPAM=spam, NOT_SPAM=not_spam)]",
        )
```
